### PR TITLE
Add pre-fetch mode to reduce latency by pre-fetching all flags upon f…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-VERSION = '0.0.8'
+VERSION = "0.0.10"
 
 
 setuptools.setup(
@@ -17,23 +17,25 @@ setuptools.setup(
     url="https://github.com/Optibus/tonga-py",
     packages=setuptools.find_packages(),
     install_requires=[
-        'six>=1.15.0',
-        'requests==2.24',
+        "six>=1.15.0",
+        "requests==2.24",
     ],
-    extras_require={'dev': [
-        'mock==2.0.0',
-        'requests-mock==1.9.3',
-        'pytest==4.6.9',
-        'pylint==2.6.0; python_version > "3.0"',
-        'pylint-junit==0.3.2; python_version > "3.0"',
-        'flake8==3.8.4; python_version > "3.0"',
-        'flake8-formatter-junit-xml==0.0.6; python_version > "3.0"',
-    ]},
+    extras_require={
+        "dev": [
+            "mock==2.0.0",
+            "requests-mock==1.9.3",
+            "pytest==4.6.9",
+            'pylint==2.6.0; python_version > "3.0"',
+            'pylint-junit==0.3.2; python_version > "3.0"',
+            'flake8==3.8.4; python_version > "3.0"',
+            'flake8-formatter-junit-xml==0.0.6; python_version > "3.0"',
+        ]
+    },
     classifiers=[
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=2.7',
+    python_requires=">=2.7",
 )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         "six>=1.15.0",
-        "requests==2.24",
+        'requests==2.24; python_version < "3.0"',
+        'requests>=2.24; python_version > "3.0"',
     ],
     extras_require={
         "dev": [

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -18,7 +18,7 @@ class TestClient(unittest.TestCase):
     @requests_mock.Mocker()
     def test_on_demand_fetch_single_non_existing_flag(self, m):
         server_url = "http://server_url"
-        m.get('{}/flag_value/flag_name'.format(server_url), status_code=404)
+        m.get("{}/flag_value/flag_name".format(server_url), status_code=404)
         client = TongaClient(server_url)
         flag_value = client.get("flag_name")
         self.assertIsNone(flag_value)
@@ -26,7 +26,7 @@ class TestClient(unittest.TestCase):
     @requests_mock.Mocker()
     def test_on_demand_fetch_single_no_value_in_response(self, m):
         server_url = "http://server_url"
-        m.get('{}/flag_value/flag_name'.format(server_url), json=dict())
+        m.get("{}/flag_value/flag_name".format(server_url), json=dict())
         client = TongaClient(server_url)
         flag_value = client.get("flag_name")
         self.assertIsNone(flag_value)
@@ -34,7 +34,7 @@ class TestClient(unittest.TestCase):
     @requests_mock.Mocker()
     def test_on_demand_fetch_single_boolean_flag(self, m):
         server_url = "http://server_url"
-        m.get('{}/flag_value/flag_name'.format(server_url), json=dict(value=True))
+        m.get("{}/flag_value/flag_name".format(server_url), json=dict(value=True))
         client = TongaClient(server_url)
         flag_value = client.get("flag_name")
         # assertTrue return true if bool(flag_value) is True, hence we use equals to check if the value is actually True
@@ -43,25 +43,25 @@ class TestClient(unittest.TestCase):
     @requests_mock.Mocker()
     def test_on_demand_fetch_single_boolean_flag_with_context_attributes(self, m):
         server_url = "http://server_url"
-        m.get('{}/flag_value/flag_name?user=some+user1&some_attribute=2'.format(server_url), json=dict(value=True))
-        m.get('{}/flag_value/flag_name?user=some+user2&some_attribute=2'.format(server_url), json=dict(value=False))
-        m.get('{}/flag_value/flag_name?user=some+user2&some_attribute=3'.format(server_url), status_code=404)
-        client = TongaClient(server_url, context_attributes=dict(user='some user1', some_attribute=2))
+        m.get("{}/flag_value/flag_name?user=some+user1&some_attribute=2".format(server_url), json=dict(value=True))
+        m.get("{}/flag_value/flag_name?user=some+user2&some_attribute=2".format(server_url), json=dict(value=False))
+        m.get("{}/flag_value/flag_name?user=some+user2&some_attribute=3".format(server_url), status_code=404)
+        client = TongaClient(server_url, context_attributes=dict(user="some user1", some_attribute=2))
         flag_value = client.get("flag_name")
         self.assertEqual(True, flag_value)
 
-        client = TongaClient(server_url, context_attributes=dict(user='some user2', some_attribute=2))
+        client = TongaClient(server_url, context_attributes=dict(user="some user2", some_attribute=2))
         flag_value = client.get("flag_name")
         self.assertEqual(False, flag_value)
 
-        client = TongaClient(server_url, context_attributes=dict(user='some user2', some_attribute=3))
+        client = TongaClient(server_url, context_attributes=dict(user="some user2", some_attribute=3))
         flag_value = client.get("flag_name")
         self.assertIsNone(flag_value)
 
     @requests_mock.Mocker()
     def test_on_demand_fetch_single_boolean_flag_cached_result(self, m):
         server_url = "http://server_url"
-        m.get('{}/flag_value/flag_name'.format(server_url), json=dict(value=True))
+        m.get("{}/flag_value/flag_name".format(server_url), json=dict(value=True))
         client = TongaClient(server_url)
         flag_value = client.get("flag_name")
         self.assertEqual(True, flag_value)
@@ -72,7 +72,7 @@ class TestClient(unittest.TestCase):
     @requests_mock.Mocker()
     def test_offline_mode_fetch(self, m):
         server_url = "http://server_url"
-        m.get('{}/flag_value/flag_name'.format(server_url), text="true")
+        m.get("{}/flag_value/flag_name".format(server_url), text="true")
         client = TongaClient(server_url, options=TongaClientOptions(offline_mode=True))
         flag_value = client.get("flag_name", offline_value=False)
         self.assertEqual(False, flag_value)
@@ -81,19 +81,42 @@ class TestClient(unittest.TestCase):
     @requests_mock.Mocker()
     def test_on_demand_fetch_single_boolean_flag_with_context_and_request_attributes(self, m):
         server_url = "http://server_url"
-        m.get('{}/flag_value/flag_name?user=some+user1&some_attribute=2'.format(server_url), json=dict(value=True))
-        client = TongaClient(server_url, context_attributes=dict(user='some user1', some_attribute=2),
-                             request_attributes=dict(attr1='val1', attr2='val2'))
+        m.get("{}/flag_value/flag_name?user=some+user1&some_attribute=2".format(server_url), json=dict(value=True))
+        client = TongaClient(
+            server_url,
+            context_attributes=dict(user="some user1", some_attribute=2),
+            request_attributes=dict(attr1="val1", attr2="val2"),
+        )
         flag_value = client.get("flag_name")
         self.assertEqual(True, flag_value)
-        self.assertEqual('val1', m.last_request.headers['X-Tonga-attr1'])
-        self.assertEqual('val2', m.last_request.headers['X-Tonga-attr2'])
+        self.assertEqual("val1", m.last_request.headers["X-Tonga-attr1"])
+        self.assertEqual("val2", m.last_request.headers["X-Tonga-attr2"])
+
+    @requests_mock.Mocker()
+    def test_pre_fetch_fetch_single_boolean_flag_cached_result(self, m):
+        server_url = "http://server_url"
+        m.get("{}/all_flags_values".format(server_url), json=dict(flag_name1=True, flag_name2=2))
+        client = TongaClient(server_url, options=TongaClientOptions(pre_fetch=True))
+        flag1_value = client.get("flag_name1")
+        self.assertEqual(True, flag1_value)
+        flag2_value = client.get("flag_name2")
+        self.assertEqual(2, flag2_value)
+        self.assertEqual(1, m.call_count)
+
+    @requests_mock.Mocker()
+    def test_pre_fetch_fetch_not_found_response(self, m):
+        server_url = "http://server_url"
+        m.get("{}/all_flags_values".format(server_url), status_code=404)
+        client = TongaClient(server_url, options=TongaClientOptions(pre_fetch=True))
+        self.assertIsNone(client.get("flag_name"))
+        self.assertIsNone(client.get("flag_name2"))
+        self.assertEqual(1, m.call_count)
 
     @requests_mock.Mocker()
     def test_dump_init_cache_state(self, m):
         server_url = "http://server_url"
-        m.get('{}/flag_value/flag_name1'.format(server_url), json=dict(value=True))
-        m.get('{}/flag_value/flag_name2'.format(server_url), json=dict(value=2))
+        m.get("{}/flag_value/flag_name1".format(server_url), json=dict(value=True))
+        m.get("{}/flag_value/flag_name2".format(server_url), json=dict(value=2))
         client = TongaClient(server_url)
         client.get("flag_name1")
         client.get("flag_name2")
@@ -115,8 +138,8 @@ class TestClient(unittest.TestCase):
     @requests_mock.Mocker()
     def test_with_set_state(self, m):
         server_url = "http://server_url"
-        m.get('{}/flag_value/flag_name1'.format(server_url), json=dict(value=True))
-        m.get('{}/flag_value/flag_name2'.format(server_url), json=dict(value=2))
+        m.get("{}/flag_value/flag_name1".format(server_url), json=dict(value=True))
+        m.get("{}/flag_value/flag_name2".format(server_url), json=dict(value=2))
         client = TongaClient(server_url)
         client.get("flag_name1")
         client.get("flag_name2")
@@ -134,24 +157,30 @@ class TestClient(unittest.TestCase):
     @requests_mock.Mocker()
     def test_with_unicode_header_value(self, m):
         server_url = "http://server_url"
-        m.get('{}/flag_value/flag_name?user=some+user1&some_attribute=2'.format(server_url), json=dict(value=True))
-        client = TongaClient(server_url, context_attributes=dict(user='some user1', some_attribute=2),
-                             request_attributes=dict(attr1=u'PróUrbano SP', attr2='val2'))
+        m.get("{}/flag_value/flag_name?user=some+user1&some_attribute=2".format(server_url), json=dict(value=True))
+        client = TongaClient(
+            server_url,
+            context_attributes=dict(user="some user1", some_attribute=2),
+            request_attributes=dict(attr1=u"PróUrbano SP", attr2="val2"),
+        )
         flag_value = client.get("flag_name")
         self.assertEqual(True, flag_value)
-        self.assertEqual(six.ensure_str(u'PróUrbano SP'), m.last_request.headers['X-Tonga-attr1'])
-        self.assertEqual('val2', m.last_request.headers['X-Tonga-attr2'])
+        self.assertEqual(six.ensure_str(u"PróUrbano SP"), m.last_request.headers["X-Tonga-attr1"])
+        self.assertEqual("val2", m.last_request.headers["X-Tonga-attr2"])
 
     @requests_mock.Mocker()
     def test_with_none_header_value(self, m):
         server_url = "http://server_url"
-        m.get('{}/flag_value/flag_name?user=some+user1&some_attribute=2'.format(server_url), json=dict(value=True))
-        client = TongaClient(server_url, context_attributes=dict(user='some user1', some_attribute=2),
-                             request_attributes=dict(attr1=None, attr2='val2'))
+        m.get("{}/flag_value/flag_name?user=some+user1&some_attribute=2".format(server_url), json=dict(value=True))
+        client = TongaClient(
+            server_url,
+            context_attributes=dict(user="some user1", some_attribute=2),
+            request_attributes=dict(attr1=None, attr2="val2"),
+        )
         flag_value = client.get("flag_name")
         self.assertEqual(True, flag_value)
-        self.assertNotIn('X-Tonga-attr1', m.last_request.headers)
-        self.assertEqual('val2', m.last_request.headers['X-Tonga-attr2'])
+        self.assertNotIn("X-Tonga-attr1", m.last_request.headers)
+        self.assertEqual("val2", m.last_request.headers["X-Tonga-attr2"])
 
     def test_retry_upon_get_exception(self):
         server_url = "http://server_url"
@@ -159,15 +188,19 @@ class TestClient(unittest.TestCase):
         good_response.status_code = 200
         good_response.json.return_value = dict(value=True)
         # Raise error 5 times, retry is set to 5 so it should work
-        with patch('tonga.client.requests.get',
-                   side_effect=[requests.exceptions.ConnectionError("error")] * 5 + [good_response]):
+        with patch(
+            "tonga.client.requests.get",
+            side_effect=[requests.exceptions.ConnectionError("error")] * 5 + [good_response],
+        ):
             client = TongaClient(server_url, options=TongaClientOptions(retry_delay=0.01, retries=5))
             flag_value = client.get("flag_name")
             self.assertEqual(True, flag_value)
 
         # Raise error 5 times, retry is set to 4 so it should fail
-        with patch('tonga.client.requests.get',
-                   side_effect=[requests.exceptions.ConnectionError("error")] * 5 + [good_response]):
+        with patch(
+            "tonga.client.requests.get",
+            side_effect=[requests.exceptions.ConnectionError("error")] * 5 + [good_response],
+        ):
             client = TongaClient(server_url, options=TongaClientOptions(retry_delay=0.01, retries=4))
             with self.assertRaises(requests.exceptions.ConnectionError):
                 client.get("flag_name")
@@ -181,19 +214,17 @@ class TestClient(unittest.TestCase):
         good_response.status_code = 200
         good_response.json.return_value = dict(value=True)
         # Raise error 5 times, retry is set to 5 so it should work
-        with patch('tonga.client.requests.get',
-                   side_effect=[error_response] * 5 + [good_response]):
+        with patch("tonga.client.requests.get", side_effect=[error_response] * 5 + [good_response]):
             client = TongaClient(server_url, options=TongaClientOptions(retry_delay=0.01, retries=5))
             flag_value = client.get("flag_name")
             self.assertEqual(True, flag_value)
 
         # Raise error 5 times, retry is set to 4 so it should fail
-        with patch('tonga.client.requests.get',
-                   side_effect=[error_response] * 5 + [good_response]):
+        with patch("tonga.client.requests.get", side_effect=[error_response] * 5 + [good_response]):
             client = TongaClient(server_url, options=TongaClientOptions(retry_delay=0.01, retries=4))
             with self.assertRaises(requests.exceptions.ConnectionError):
                 client.get("flag_name")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add pre-fetch mode to reduce latency by pre-fetching all flags upon first request.
Black formatting was also applied in this PR, it is hard to separate it into 2 commits as my IDE automatically did it while I worked :(

Consolidate 0.0.8 and 0.0.9 logic for python version support so we don't need two different tags