### PR TITLE
Add latency and pre fetch method extraction

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-VERSION = "0.0.11"
+VERSION = "0.0.12"
 
 
 setuptools.setup(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -197,18 +197,20 @@ class TestClient(unittest.TestCase):
             "tonga.client.requests.get",
             side_effect=[requests.exceptions.ConnectionError("error")] * 5 + [good_response],
         ):
-            client = TongaClient(server_url, options=TongaClientOptions(retry_delay=0.01, retries=5))
+            client = TongaClient(server_url, options=TongaClientOptions(retry_delay=0.1, retries=5))
             flag_value = client.get("flag_name")
             self.assertEqual(True, flag_value)
+            self.assertAlmostEquals(0.55, client.accumulated_latency, delta=0.1)
 
         # Raise error 5 times, retry is set to 4 so it should fail
         with patch(
             "tonga.client.requests.get",
             side_effect=[requests.exceptions.ConnectionError("error")] * 5 + [good_response],
         ):
-            client = TongaClient(server_url, options=TongaClientOptions(retry_delay=0.01, retries=4))
+            client = TongaClient(server_url, options=TongaClientOptions(retry_delay=0.1, retries=4))
             with self.assertRaises(requests.exceptions.ConnectionError):
                 client.get("flag_name")
+            self.assertAlmostEquals(0.44, client.accumulated_latency, delta=0.1)
 
     def test_retry_upon_raise_for_status(self):
         server_url = "http://server_url"


### PR DESCRIPTION
Introduces 2 small changes:
1. Add server latency collection properties for metrics collections
2. Extract several of the pre-fetch flows introduced in 0.0.11 to allow more flexible usage and init of prefetching in `TongaClient` usages

Bump to ver 0.0.12 to distribute new changes